### PR TITLE
IMR-179 feat: PlaylistRepository.find_by_genie_id 성능개선

### DIFF
--- a/db/repository/album.py
+++ b/db/repository/album.py
@@ -39,3 +39,15 @@ class AlbumRepository:
     def find_all(self) -> list[Album]:
         albums: QuerySet[AlbumDocument] = AlbumDocument.objects
         return [album.to_dto() for album in albums]
+
+    @classmethod
+    def _album_dict2dto(cls, album_dict) -> Album:
+        return Album(
+            id=str(album_dict["_id"]),
+            genie_id=album_dict["genie_id"],
+            name=album_dict["name"],
+            img_url=album_dict["img_url"],
+            released_date=album_dict["released_date"],
+            created_at=album_dict["created_at"],
+            updated_at=album_dict["updated_at"],
+        )

--- a/db/repository/artist.py
+++ b/db/repository/artist.py
@@ -38,3 +38,13 @@ class ArtistRepository:
     def find_all(self) -> list[Artist]:
         artists: QuerySet[ArtistDocument] = ArtistDocument.objects
         return [artist.to_dto() for artist in artists]
+
+    @classmethod
+    def _artist_dict2dto(cls, artist_dict) -> Artist:
+        return Artist(
+            id=str(artist_dict["_id"]),
+            genie_id=artist_dict["genie_id"],
+            name=artist_dict["name"],
+            created_at=artist_dict["created_at"],
+            updated_at=artist_dict["updated_at"],
+        )

--- a/db/repository/playlist.py
+++ b/db/repository/playlist.py
@@ -1,9 +1,11 @@
-from ..document import PlaylistDocument
+from ..document import PlaylistDocument, SongDocument
 from ..exception import NotFoundPlaylistException
 from ..model import Playlist, Song
 from .common import find_song_docs_by_dto
+from .song import SongRepository
 from datetime import datetime
 from mongoengine import QuerySet
+from pymongo.command_cursor import CommandCursor
 
 
 class PlaylistRepository:
@@ -43,12 +45,16 @@ class PlaylistRepository:
         playlist.delete()
 
     def find_by_genie_id(self, genie_id: str) -> Playlist:
-        playlist: PlaylistDocument = PlaylistDocument.objects(genie_id=genie_id).first()
+        pipeline = [{"$match": {"genie_id": genie_id}}, *self._population_pipeline()]
 
-        if not playlist:
+        result: CommandCursor = PlaylistDocument.objects.aggregate(*pipeline)
+
+        if not result:
             return None
 
-        return playlist.to_dto()
+        playlist_dict = result.next()
+
+        return self._playlist_dict2dto(playlist_dict=playlist_dict)
 
     def find_by_updated_at_gte(self, query_dt: datetime) -> list[Playlist]:
         playlists: QuerySet[PlaylistDocument] = PlaylistDocument.objects(updated_at__gte=query_dt)
@@ -61,3 +67,34 @@ class PlaylistRepository:
     def find_all(self) -> list[Playlist]:
         playlists: QuerySet[PlaylistDocument] = PlaylistDocument.objects
         return [playlist.to_dto() for playlist in playlists]
+
+    @classmethod
+    def _population_pipeline(cls) -> list[dict]:
+        return [
+            {
+                "$lookup": {
+                    "from": SongDocument._get_collection_name(),
+                    "localField": "songs",
+                    "foreignField": "_id",
+                    "as": "songs",
+                    "pipeline": SongRepository._population_pipeline(),
+                }
+            },
+        ]
+
+    @classmethod
+    def _playlist_dict2dto(cls, playlist_dict) -> Playlist:
+        return Playlist(
+            id=str(playlist_dict["_id"]),
+            genie_id=playlist_dict["genie_id"],
+            title=playlist_dict["title"],
+            subtitle=playlist_dict["subtitle"],
+            song_cnt=playlist_dict["song_cnt"],
+            like_cnt=playlist_dict["like_cnt"],
+            view_cnt=playlist_dict["view_cnt"],
+            tags=playlist_dict["tags"],
+            songs=[SongRepository._song_dict2dto(song_dict) for song_dict in playlist_dict["songs"]],
+            img_url=playlist_dict["img_url"],
+            created_at=playlist_dict["created_at"],
+            updated_at=playlist_dict["updated_at"],
+        )


### PR DESCRIPTION
## Overview
기존 코드는 mongoengine의 기능들을 사용해 하나의 document마다 하나의 리퀘스트를 보냅니다.

따라서 45개의 플리가 각각 20개의 수록곡을 가진다면 대략 45 + 45*(20 + 20*2) = 2745 만큼 쿼리를 날려야 합니다.

본 이슈에선 pymongo를 이용해 모든 document를 동시에 가져오는 하나의 쿼리를 날리게 됩니다.

같은 조건에서 속도를 6배로 개선시켰습니다.

## To Reviewer
- 테스트할때 사용한 가짜 db; mongomock가 aggregate를 지원하지 않는다고 하네요.. 실 서버에서 테스트 해봤으니 일단은 넘어가주세욤

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/browse/IMR-179?atlOrigin=eyJpIjoiN2IwZmFkZWM1OTgyNDU1OWI1ZjBiZDk0YjQ3ZGQzYjEiLCJwIjoiaiJ9)
